### PR TITLE
build: update wasm target name

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"


### PR DESCRIPTION
AFAIK latest rustc doesn't support `wasm32-wasi` target and the Zellij example plugin uses `wasm32-wasip1` target, so should this plugin. Otherwise, I can't compile it.
